### PR TITLE
Android 8.0 (Oreo)에서 인텐트 미지원 브라우저로 인식되는 문제 수정

### DIFF
--- a/lib/web2app.js
+++ b/lib/web2app.js
@@ -11,7 +11,7 @@
             os = ua.os,
             intentNotSupportedBrowserList = [
                 'firefox',
-                'opr'
+                'opr/'
             ];
 
         function moveToStore (storeURL) {


### PR DESCRIPTION
Android 8.0은 User-Agent 헤더에 `OPR`이 포함되어 있어서 오페라 브라우저로 잘못 인식되는 문제가 있습니다. (빌드 넘버가 `OPR`로 시작하기 때문입니다.)

예: `Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36`)

Opera는 `OPR/...` 형식의 User-Agent를 포함하고 있으므로 ([참고 자료](https://dev.opera.com/blog/opera-user-agent-strings-opera-15-and-beyond/)) `opr` 대신 `opr/`을 인식하도록 변경하였습니다.